### PR TITLE
Add navigation for password change and hide login left section 

### DIFF
--- a/client/src/components/organisms/UserPortal/Userprofile/Userprofile.jsx
+++ b/client/src/components/organisms/UserPortal/Userprofile/Userprofile.jsx
@@ -5,6 +5,7 @@ import moment from "moment";
 import { useAuth } from "../../../../contexts/AuthContext.jsx";
 import { useTheme } from "../../../../contexts/ThemeContext.jsx";
 import leftimag from "../../../../assets/Logo/profile.jpg";
+import { useNavigate } from "react-router-dom";
 
 export default function UserProfile({ user }) {
   const [isEditing, setIsEditing] = useState(false);
@@ -340,6 +341,8 @@ export default function UserProfile({ user }) {
     });
   };
 
+  const navigate = useNavigate();
+
   if (!userData) {
     return <div style={{ color: isDark ? 'var(--text-primary)' : '#1a202c' }}>Loading...</div>;
   }
@@ -623,8 +626,7 @@ export default function UserProfile({ user }) {
               <button 
                 style={styles.passwordChangeButton}
                 onClick={() => {
-                  // Add your password change navigation logic here
-                  console.log('Navigate to password change');
+                  navigate('/forgotpassword');
                 }}
                 onMouseEnter={e => e.target.style.backgroundColor = isDark ? '#16a34a' : '#047857'}
                 onMouseLeave={e => e.target.style.backgroundColor = isDark ? 'var(--success)' : '#059669'}

--- a/client/src/components/pages/Login/PasswordReset/PasswordReset.module.css
+++ b/client/src/components/pages/Login/PasswordReset/PasswordReset.module.css
@@ -156,3 +156,9 @@
     transform: rotate(360deg);
   }
 }
+
+@media (max-width: 768px) {
+  .loginLeft {
+    display: none;
+  }
+}


### PR DESCRIPTION
This pull request introduces navigation functionality for the password change button in the `UserProfile` component and adds responsive styling to the `PasswordReset` page. Below are the most important changes:

### Navigation Enhancements in `UserProfile`:

* Added the `useNavigate` hook from `react-router-dom` to enable navigation within the `UserProfile` component (`client/src/components/organisms/UserPortal/Userprofile/Userprofile.jsx`) [[1]](diffhunk://#diff-e0aed6f7af70dff6a57672f14e549347c1b474b278ffa9bcae8d32813cc424f5R8) [[2]](diffhunk://#diff-e0aed6f7af70dff6a57672f14e549347c1b474b278ffa9bcae8d32813cc424f5R344-R345).
* Updated the password change button's `onClick` handler to navigate to the `/forgotpassword` route instead of logging a placeholder message (`client/src/components/organisms/UserPortal/Userprofile/Userprofile.jsx`).

### Responsive Design Updates:

* Added a media query to hide the `.loginLeft` element on screen widths of 768px or smaller to improve the responsiveness of the `PasswordReset` page (`client/src/components/pages/Login/PasswordReset/PasswordReset.module.css`).…ll screens